### PR TITLE
Adding mmpose

### DIFF
--- a/dev/main.tf
+++ b/dev/main.tf
@@ -28,8 +28,6 @@ module "processing" {
     processing_asg_scaling_target  = 5
     processing_asg_trials_baseline = 3
 
-    processing_asg_use_launch_config = false
-
     # processing_asg_instance_type = "g5.2xlarge"
     # processing_ecs_task_memory = 30146
     processing_asg_instance_type = "g5.xlarge"

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -21,7 +21,7 @@ module "processing" {
 
     processing_asg_scaling_config = {
         min_size = 0
-        max_size = 0
+        max_size = 2
         desired_size = 0
     }
 

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -29,6 +29,7 @@ module "processing" {
 
     processing_asg_use_launch_config = false
 
+    # processing_asg_instance_type = "g5.2xlarge"
     processing_asg_instance_type = "g5.xlarge"
     
     source = "../modules/processing"

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -2,9 +2,9 @@ module "processing" {
     region = "us-west-2"
     num_machines = 0
     opencap_ecr_repository = "660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap/opencap-dev"
-    openpose_ecr_repository = "660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap/openpose"
+    openpose_ecr_repository = "660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap/openpose-dev"
     opencap_api_ecr_repository = "660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap/api-dev"
-    mmpose_ecr_repository = "660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap/mmpose"
+    mmpose_ecr_repository = "660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap/mmpose-dev"
     opencap_analysis_max_centerofmass_vpos_ecr_repository = "660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap-analysis/max_centerofmass_vpos-dev"
     opencap_gait_analysis_ecr_repository = "660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap-analysis/gait_analysis-dev"
     opencap_treadmill_gait_analysis_ecr_repository = "660440363484.dkr.ecr.us-west-2.amazonaws.com/opencap-analysis/treadmill_gait_analysis-dev"
@@ -21,7 +21,7 @@ module "processing" {
 
     processing_asg_scaling_config = {
         min_size = 0
-        max_size = 2
+        max_size = 0
         desired_size = 0
     }
 

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -30,9 +30,9 @@ module "processing" {
     processing_asg_use_launch_config = false
 
     # processing_asg_instance_type = "g5.2xlarge"
-    # processing_ecs_task_memory = 32000
+    # processing_ecs_task_memory = 30146
     processing_asg_instance_type = "g5.xlarge"
-    processing_ecs_task_memory = 15616
+    processing_ecs_task_memory = 15073
     
     source = "../modules/processing"
 }

--- a/dev/main.tf
+++ b/dev/main.tf
@@ -21,7 +21,7 @@ module "processing" {
 
     processing_asg_scaling_config = {
         min_size = 0
-        max_size = 2
+        max_size = 0
         desired_size = 0
     }
 

--- a/modules/processing/autoscaling.tf
+++ b/modules/processing/autoscaling.tf
@@ -27,7 +27,7 @@ data "aws_ami" "latest_ecs" {
 locals {
     lt_user_data_raw = <<-EOF
     #!/bin/bash
-    echo ECS_CLUSTER=${aws_ecs_cluster.cluster.name} >> /etc/ecs/ecs.config
+    echo ECS_CLUSTER=${aws_ecs_cluster.ecs_cluster.name} >> /etc/ecs/ecs.config
     EOF
 }
 
@@ -82,6 +82,18 @@ resource "aws_autoscaling_group" "worker_lt_asg" {
 
     health_check_grace_period = 300
     health_check_type         = "EC2"
+
+    tag {
+        key                 = "AmazonECSManaged"
+        value               = true
+        propagate_at_launch = true
+    }
+
+    lifecycle {
+      ignore_changes = [
+        desired_capacity,
+      ]
+    }
 }
 
 ## Link ASG to ECS

--- a/modules/processing/autoscaling.tf
+++ b/modules/processing/autoscaling.tf
@@ -31,11 +31,17 @@ locals {
     echo 'ECS_CLUSTER=${aws_ecs_cluster.ecs_cluster.name}' >> /etc/ecs/ecs.config
     echo 'ECS_ENABLE_CONTAINER_METADATA=true' >> /etc/ecs/ecs.config
     echo 'ECS_RESERVED_MEMORY=256' >> /etc/ecs/ecs.config
+    # Install jq
+    apt update && apt install -y jq
     # Modify Docker config to allow GPU sharing
-    sudo rm /etc/sysconfig/docker
-    echo DAEMON_MAXFILES=1048576 | sudo tee -a /etc/sysconfig/docker
-    echo OPTIONS="--default-ulimit nofile=32768:65536 --default-runtime nvidia" | sudo tee -a /etc/sysconfig/docker
-    echo DAEMON_PIDFILE_TIMEOUT=10 | sudo tee -a /etc/sysconfig/docker
+    # Backup existing daemon.json
+    if [ ! -f /etc/docker/daemon.json ]; then
+        echo '{}' > /etc/docker/daemon.json
+    fi
+    sudo cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
+    # Update the daemon.json file
+    sudo jq '. + {"default-ulimit": {"nofile": ["32768:65536"]}, "default-runtime": "nvidia"}' /etc/docker/daemon.json.orig | sudo tee /etc/docker/daemon.json
+    # Restart Docker to apply changes
     sudo systemctl restart docker
     EOF
 }

--- a/modules/processing/autoscaling.tf
+++ b/modules/processing/autoscaling.tf
@@ -31,18 +31,6 @@ locals {
     echo 'ECS_CLUSTER=${aws_ecs_cluster.ecs_cluster.name}' >> /etc/ecs/ecs.config
     echo 'ECS_ENABLE_CONTAINER_METADATA=true' >> /etc/ecs/ecs.config
     echo 'ECS_RESERVED_MEMORY=256' >> /etc/ecs/ecs.config
-    # Install jq
-    apt update && apt install -y jq
-    # Modify Docker config to allow GPU sharing
-    # Backup existing daemon.json
-    if [ ! -f /etc/docker/daemon.json ]; then
-        echo '{}' > /etc/docker/daemon.json
-    fi
-    sudo cp /etc/docker/daemon.json /etc/docker/daemon.json.orig
-    # Update the daemon.json file
-    sudo jq '. + {"default-ulimit": {"nofile": ["32768:65536"]}, "default-runtime": "nvidia"}' /etc/docker/daemon.json.orig | sudo tee /etc/docker/daemon.json
-    # Restart Docker to apply changes
-    sudo systemctl restart docker
     EOF
 }
 

--- a/modules/processing/ecs.tf
+++ b/modules/processing/ecs.tf
@@ -63,10 +63,6 @@ resource "aws_ecs_task_definition" "task_definition" {
   container_definitions = data.template_file.task_definition_template.rendered
   execution_role_arn    = aws_iam_role.ecs_tasks_execution_role.arn
   task_role_arn         = aws_iam_role.processing_worker_role.arn
-  # 31680(15840*2) should be the one to saturate g5.2xlarge
-  # 15840 available for tasks on g5.xlarge
-  # memory                = 15840 # TODO might need to be adjusted to support bigger jobs/instances.
-  # memory                = 31680 # TODO might need to be adjusted to support bigger jobs/instances.
   memory                = var.processing_ecs_task_memory
   volume {
     name = "data${var.env}"

--- a/modules/processing/ecs.tf
+++ b/modules/processing/ecs.tf
@@ -63,6 +63,7 @@ resource "aws_ecs_task_definition" "task_definition" {
   container_definitions = data.template_file.task_definition_template.rendered
   execution_role_arn    = aws_iam_role.ecs_tasks_execution_role.arn
   task_role_arn         = aws_iam_role.processing_worker_role.arn
+  
   memory                = var.processing_ecs_task_memory
   volume {
     name = "data${var.env}"

--- a/modules/processing/ecs.tf
+++ b/modules/processing/ecs.tf
@@ -2,17 +2,19 @@ resource "aws_ecs_cluster" "ecs_cluster" {
   name  = "${var.app_name}-processing-cluster${var.env}"
 }
 
-# resource "aws_ecs_cluster_capacity_providers" "default-fargate" {
-#   cluster_name = aws_ecs_cluster.ecs_cluster.name
+resource "aws_ecs_cluster_capacity_providers" "default" {
+  cluster_name = aws_ecs_cluster.ecs_cluster.name
 
-#   capacity_providers = ["FARGATE"]
+  capacity_providers = [
+    aws_ecs_capacity_provider.worker_lt_gpu_provider.name,
+  ]
 
-#   default_capacity_provider_strategy {
-#     base              = 1
-#     weight            = 100
-#     capacity_provider = "FARGATE"
-#   }
-# }
+  default_capacity_provider_strategy {
+    base              = 0
+    weight            = 100
+    capacity_provider = aws_ecs_capacity_provider.worker_lt_gpu_provider.name
+  }
+}
 
 resource "aws_ecs_service" "worker" {
   name            = "worker"
@@ -26,6 +28,12 @@ resource "aws_ecs_service" "worker" {
   capacity_provider_strategy {
     capacity_provider = aws_ecs_capacity_provider.worker_lt_gpu_provider.name
     weight = 100
+  }
+
+  lifecycle {
+    ignore_changes = [
+      desired_count,
+    ]
   }
 }
 
@@ -44,8 +52,9 @@ resource "aws_ecs_task_definition" "task_definition" {
   container_definitions = data.template_file.task_definition_template.rendered
   execution_role_arn    = aws_iam_role.ecs_tasks_execution_role.arn
   task_role_arn         = aws_iam_role.processing_worker_role.arn
-  # Optional for ECS on EC2, 32768 to saturate g5.2xlarge
-  memory                = 16384 # TODO might need to be adjusted to support bigger jobs/instances.
+  # 31680(15840*2) should be the one to saturate g5.2xlarge
+  # 15840 available for tasks on g5.xlarge
+  memory                = 15840 # TODO might need to be adjusted to support bigger jobs/instances.
   volume {
     name = "data${var.env}"
   }

--- a/modules/processing/ecs.tf
+++ b/modules/processing/ecs.tf
@@ -47,6 +47,11 @@ resource "aws_cloudwatch_log_group" "openpose-logs" {
   retention_in_days = 90
 }
 
+resource "aws_cloudwatch_log_group" "mmpose-logs" {
+  name              = "/ecs/${var.app_name}-mmpose${var.env}"
+  retention_in_days = 90
+}
+
 resource "aws_ecs_task_definition" "task_definition" {
   family                = "worker${var.env}"
   container_definitions = data.template_file.task_definition_template.rendered

--- a/modules/processing/ecs.tf
+++ b/modules/processing/ecs.tf
@@ -60,6 +60,7 @@ resource "aws_ecs_task_definition" "task_definition" {
   # 31680(15840*2) should be the one to saturate g5.2xlarge
   # 15840 available for tasks on g5.xlarge
   memory                = 15840 # TODO might need to be adjusted to support bigger jobs/instances.
+  # memory                = 31680 # TODO might need to be adjusted to support bigger jobs/instances.
   volume {
     name = "data${var.env}"
   }

--- a/modules/processing/fargate.tf
+++ b/modules/processing/fargate.tf
@@ -85,7 +85,7 @@ locals {
         OPENCAP_API = "${var.opencap_api_ecr_repository}"
         API_HOST = "${var.api_host}"
         APP_NAME = "${var.app_name}"
-        API_TOKEN = "arn:aws:secretsmanager:us-west-2:660440363484:secret:APICredentials-Dag8bw:api_token::"
+        API_TOKEN = var.env == "-dev" ? "arn:aws:secretsmanager:us-west-2:660440363484:secret:APICredentials-Dag8bw:api_token_dev::" : "arn:aws:secretsmanager:us-west-2:660440363484:secret:APICredentials-Dag8bw:api_token::"
         API_AWS_KEY = "arn:aws:secretsmanager:us-west-2:660440363484:secret:APICredentials-Dag8bw:aws_access_key_id::"
         API_AWS_SECRET = "arn:aws:secretsmanager:us-west-2:660440363484:secret:APICredentials-Dag8bw:aws_secret_access_key::"
         SENDGRID_API_KEY = "arn:aws:secretsmanager:us-west-2:660440363484:secret:APICredentials-Dag8bw:sendgrid_api_key::"

--- a/modules/processing/task_definition.json.tpl
+++ b/modules/processing/task_definition.json.tpl
@@ -20,10 +20,6 @@
         {
           "name": "DOCKERCOMPOSE",
 	        "value": "1"
-        },
-        {
-          "name": "ECS_ENABLE_CONTAINER_METADATA",
-          "value": "true"
         }
       ],
       "secrets": [
@@ -36,7 +32,12 @@
           "valueFrom": "${API_URL}"
         }
       ],
-      "resourceRequirements": null,
+      "resourceRequirements" : [
+          {
+             "type" : "GPU",
+             "value" : "1"
+          }
+      ],
       "ulimits": null,
       "dnsServers": [],
       "mountPoints": [
@@ -90,12 +91,6 @@
       "linuxParameters": null,
       "cpu": 0,
       "environment": [],
-      "resourceRequirements" : [
-          {
-             "type" : "GPU", 
-             "value" : "1"
-          }
-      ],
       "ulimits": null,
       "dnsServers": [],
       "mountPoints": [

--- a/modules/processing/task_definition.json.tpl
+++ b/modules/processing/task_definition.json.tpl
@@ -126,7 +126,7 @@
       "systemControls": [],
       "privileged": null,
       "name": "openpose"
-    }
+    },
     {
       "dnsSearchDomains": [],
       "environmentFiles": null,

--- a/modules/processing/task_definition.json.tpl
+++ b/modules/processing/task_definition.json.tpl
@@ -32,7 +32,12 @@
           "valueFrom": "${API_URL}"
         }
       ],
-      "resourceRequirements" : null,
+      "resourceRequirements" : [
+          {
+             "type" : "GPU",
+             "value" : "1"
+          }
+      ],
       "ulimits": null,
       "dnsServers": [],
       "mountPoints": [
@@ -85,7 +90,12 @@
       "command": [],
       "linuxParameters": null,
       "cpu": 0,
-      "environment": [],
+      "environment": [
+        {
+          "name": "NVIDIA_VISIBLE_DEVICES",
+          "value": "0"
+        }
+      ],
       "ulimits": null,
       "dnsServers": [],
       "mountPoints": [
@@ -139,12 +149,11 @@
       "command": [],
       "linuxParameters": null,
       "cpu": 0,
-      "environment": [],
-      "resourceRequirements" : [
-          {
-             "type" : "GPU",
-             "value" : "1"
-          }
+      "environment": [
+        {
+          "name": "NVIDIA_VISIBLE_DEVICES",
+          "value": "0"
+        }
       ],
       "ulimits": null,
       "dnsServers": [],

--- a/modules/processing/task_definition.json.tpl
+++ b/modules/processing/task_definition.json.tpl
@@ -127,4 +127,64 @@
       "privileged": null,
       "name": "openpose"
     }
+    {
+      "dnsSearchDomains": [],
+      "environmentFiles": null,
+      "logConfiguration": {
+        "logDriver": "awslogs",
+        "secretOptions": null,
+        "options": {
+          "awslogs-group": "/ecs/${APP_NAME}-mmpose${ENV}",
+          "awslogs-region": "${REGION}",
+          "awslogs-stream-prefix": "ecs"
+        }
+      },
+      "entryPoint": [],
+      "portMappings": [
+      ],
+      "command": [],
+      "linuxParameters": null,
+      "cpu": 0,
+      "environment": [],
+      "resourceRequirements" : [
+          {
+             "type" : "GPU", 
+             "value" : "1"
+          }
+      ],
+      "ulimits": null,
+      "dnsServers": [],
+      "mountPoints": [
+        {
+          "readOnly": false,
+          "containerPath": "/mmpose/data",
+          "sourceVolume": "data${ENV}"
+        }
+      ],
+      "workingDirectory": null,
+      "secrets": null,
+      "dockerSecurityOptions": [],
+      "memory": null,
+      "memoryReservation": null,
+      "volumesFrom": [],
+      "stopTimeout": null,
+      "image": "${MMPOSE}",
+      "startTimeout": null,
+      "firelensConfiguration": null,
+      "dependsOn": null,
+      "disableNetworking": null,
+      "interactive": null,
+      "healthCheck": null,
+      "essential": true,
+      "links": [],
+      "hostname": null,
+      "extraHosts": null,
+      "pseudoTerminal": null,
+      "user": null,
+      "readonlyRootFilesystem": null,
+      "dockerLabels": {},
+      "systemControls": [],
+      "privileged": null,
+      "name": "mmpose"
+    }
   ]

--- a/modules/processing/task_definition.json.tpl
+++ b/modules/processing/task_definition.json.tpl
@@ -150,12 +150,6 @@
       "linuxParameters": null,
       "cpu": 0,
       "environment": [],
-      "resourceRequirements" : [
-          {
-             "type" : "GPU", 
-             "value" : "1"
-          }
-      ],
       "ulimits": null,
       "dnsServers": [],
       "mountPoints": [

--- a/modules/processing/task_definition.json.tpl
+++ b/modules/processing/task_definition.json.tpl
@@ -25,7 +25,11 @@
       "secrets": [
         {
           "name": "API_TOKEN",
-	  "valueFrom": "${API_TOKEN}"
+	        "valueFrom": "${API_TOKEN}"
+        },
+        {
+          "name": "API_URL",
+          "valueFrom": "${API_URL}"
         }
       ],
       "resourceRequirements": null,

--- a/modules/processing/task_definition.json.tpl
+++ b/modules/processing/task_definition.json.tpl
@@ -90,7 +90,12 @@
       "command": [],
       "linuxParameters": null,
       "cpu": 0,
-      "environment": [],
+      "environment": [
+        {
+          "name": "NVIDIA_VISIBLE_DEVICES",
+          "value: "all"
+        }
+      ],
       "ulimits": null,
       "dnsServers": [],
       "mountPoints": [
@@ -144,7 +149,12 @@
       "command": [],
       "linuxParameters": null,
       "cpu": 0,
-      "environment": [],
+      "environment": [
+        {
+          "name": "NVIDIA_VISIBLE_DEVICES",
+          "value: "all"
+        }
+      ],
       "ulimits": null,
       "dnsServers": [],
       "mountPoints": [

--- a/modules/processing/task_definition.json.tpl
+++ b/modules/processing/task_definition.json.tpl
@@ -32,12 +32,7 @@
           "valueFrom": "${API_URL}"
         }
       ],
-      "resourceRequirements" : [
-          {
-             "type" : "GPU",
-             "value" : "1"
-          }
-      ],
+      "resourceRequirements" : null,
       "ulimits": null,
       "dnsServers": [],
       "mountPoints": [
@@ -90,12 +85,7 @@
       "command": [],
       "linuxParameters": null,
       "cpu": 0,
-      "environment": [
-        {
-          "name": "NVIDIA_VISIBLE_DEVICES",
-          "value": "all"
-        }
-      ],
+      "environment": [],
       "ulimits": null,
       "dnsServers": [],
       "mountPoints": [
@@ -149,11 +139,12 @@
       "command": [],
       "linuxParameters": null,
       "cpu": 0,
-      "environment": [
-        {
-          "name": "NVIDIA_VISIBLE_DEVICES",
-          "value": "all"
-        }
+      "environment": [],
+      "resourceRequirements" : [
+          {
+             "type" : "GPU",
+             "value" : "1"
+          }
       ],
       "ulimits": null,
       "dnsServers": [],

--- a/modules/processing/task_definition.json.tpl
+++ b/modules/processing/task_definition.json.tpl
@@ -93,7 +93,7 @@
       "environment": [
         {
           "name": "NVIDIA_VISIBLE_DEVICES",
-          "value: "all"
+          "value": "all"
         }
       ],
       "ulimits": null,
@@ -152,7 +152,7 @@
       "environment": [
         {
           "name": "NVIDIA_VISIBLE_DEVICES",
-          "value: "all"
+          "value": "all"
         }
       ],
       "ulimits": null,

--- a/modules/processing/template_file.tf
+++ b/modules/processing/template_file.tf
@@ -6,6 +6,7 @@ data "template_file" "task_definition_template" {
         APP_NAME = "${var.app_name}"
         OPENPOSE = "${var.openpose_ecr_repository}"
         OPENCAP = "${var.opencap_ecr_repository}"
-        API_TOKEN = "arn:aws:secretsmanager:us-west-2:660440363484:secret:OpenCapProcessingCredentials-oXYoTR:api_token::"
+        API_TOKEN = var.env == "-dev" ? "arn:aws:secretsmanager:us-west-2:660440363484:secret:OpenCapProcessingCredentials-oXYoTR:api_token_dev::" : "arn:aws:secretsmanager:us-west-2:660440363484:secret:OpenCapProcessingCredentials-oXYoTR:api_token::"
+        API_URL = var.env == "-dev" ? "arn:aws:secretsmanager:us-west-2:660440363484:secret:OpenCapProcessingCredentials-oXYoTR:api_url_dev::" : "arn:aws:secretsmanager:us-west-2:660440363484:secret:OpenCapProcessingCredentials-oXYoTR:api_url::"
     }
 }

--- a/modules/processing/template_file.tf
+++ b/modules/processing/template_file.tf
@@ -5,6 +5,7 @@ data "template_file" "task_definition_template" {
         ENV = "${var.env}"
         APP_NAME = "${var.app_name}"
         OPENPOSE = "${var.openpose_ecr_repository}"
+        MMPOSE = "${var.mmpose_ecr_repository}"
         OPENCAP = "${var.opencap_ecr_repository}"
         API_TOKEN = var.env == "-dev" ? "arn:aws:secretsmanager:us-west-2:660440363484:secret:OpenCapProcessingCredentials-oXYoTR:api_token_dev::" : "arn:aws:secretsmanager:us-west-2:660440363484:secret:OpenCapProcessingCredentials-oXYoTR:api_token::"
         API_URL = var.env == "-dev" ? "arn:aws:secretsmanager:us-west-2:660440363484:secret:OpenCapProcessingCredentials-oXYoTR:api_url_dev::" : "arn:aws:secretsmanager:us-west-2:660440363484:secret:OpenCapProcessingCredentials-oXYoTR:api_url::"

--- a/modules/processing/variables.tf
+++ b/modules/processing/variables.tf
@@ -70,11 +70,13 @@ variable "processing_ecs_task_memory" {
   description = <<-EOF
   We reserve 768 MiB for System & ECS agent. See `local.lt_user_data_raw`
   https://docs.aws.amazon.com/AmazonECS/latest/developerguide/memory-management.html
+  While in reality there's less memory available, so we're using conservative values here
+  https://github.com/aws/amazon-ecs-agent/issues/3331#issuecomment-1232664501
   Therefore memory value should be set accordingly to `var.processing_asg_instance_type`
-  for g5.xlarge with 16GiB memory: 16384-768 = 15616
-  for g5.2xlarge with 32GiB memory: 32768-768 = 32000
+  for g5.xlarge with 16GiB memory and 768MiB reservation AWS shows 15073 MiB registered
+  for g5.2xlarge with 32GiB memory and 768MiB reservation = let's safely assume 15073*2 = 30146 MiB
   EOF
-  default = 32000
+  default = 30146
 }
 
 variable "api_memory" {

--- a/modules/processing/variables.tf
+++ b/modules/processing/variables.tf
@@ -40,15 +40,6 @@ variable "num_machines" {
   default     = 1
 }
 
-variable "processing_asg_use_launch_config" {
-  default = true
-  description =<<-EOF
-  true: Use launch config for processing autoscaling group, false: use launch template
-  This is for providing a smooth transition from launch config to launch template as LCs are deprecated
-  the goal is to delete this variable along with LC code when all services are using launch templates
-  EOF
-}
-
 variable "processing_asg_scaling_config" {
   default = {
     min_size = 0


### PR DESCRIPTION
@sashasimkin @suhlrich @olehkorkh-planeks I could make the ASG work, or at least partly. Here are the TODOs/Bugs:

- [ ] MMPOSE is not set in task definition
   - For the core algorithm to run, we need three containers: OpenCap, OpenPose, and MMPose. The existing task definition does not include MMPose. So I added it through this PR, basically copying what we do for OpenPose (FYI OpenPose and MMPose are two containers basically doing the same thing, but using different models). However, the tasks are not starting in the processing cluster. After >15min, they are still pending/provisioning. I wondered if it was a problem with memory, because the mmpose image on ECR is 8931.13 Mb and the three images combined are over 15Gb. I tried using g5.2xlarge and doubling the memory, but I had the same issue (+ we actually have a g5.xlarge on EC2 running the core algorithm and we have no memory problem so I really don't think memory is an issue). **Do you see something missing in my PR that could explain why it does not start?**

- [x] ECS_CONTAINER_METADATA_FILE is not set
    - The instance is not recognized as an ECS instance. I temporarily commented out most of the function and returned True to keep doing some testing, but when un-commented it was going [there](https://github.com/stanfordnmbl/opencap-core/blob/dev/utilsAPI.py#L62) meaning the `ECS_CONTAINER_METADATA_FILE` was not set. ChatGPT suggested making [this change](https://github.com/stanfordnmbl/opencap-infrastructure/commit/b8f958c8fb100df723694546811aae608965543d) in the task_definition, but it did not help. **Any thoughts on what is going wrong?**

- [x] Two tasks start at once, shouldn't it be one by one?

- [x] When two tasks are active, they never stop even if the instances are unprotected.
    - Here are the logs from my tests. Tasks d6a and a3d were unprotected for [60min](https://github.com/stanfordnmbl/opencap-core/blob/dev/app.py#L59) while the # of pending trials was < the target, but the tasks never stopped. It is unclear why a 3rd task started, the max size should be 2. Interestingly, when 3 tasks were active, one (cda) actually stopped after being unprotected. My overall impression is that there is something wrong somewhere regarding the max/min/desired number of tasks. 1) It starts two at the same time, which is not expected. 2) It goes higher than 2 although the max size is set to 2. 3) It does not stop tasks when 2 are running, but it does when 3 are running.
        - 13:22 - Task cda started
        - 13:22 - Task d6a started
        - 13:29 - Task cda: Instance unprotected
        - 13:30 - Task 21a started
            - Why? Max size should be 2 and no tasks stopped yet
            - It seems to have started right after the instance of task cda got unprotected.
        - 13:32 - Task d6a: Instance unprotected
        - 13:36 - Task 21a crashed
            - Status check failed (cp: cannot stat ‘/data/output_openpose/*’: No such file or directory)
            - The task seems to have stopped by itself, but not reported under events
            - That would be a nice feature if that happened
        - 13:37 - Task a3d started
            - Why? Max size should be 2.
            - It seems to have started right after the instance of task 21a crashed
        - 13:38 - Task a3d Instance unprotected
        - 13:38 - Task cda stopped
        - 14:32 - Task d6a woke up, which is exactly 1h after it was “put to sleep”
        - 14:38 - Task a3d woke up, which is exactly 1h after it was “put to sleep”


- [ ] Need to unprotect instance if something makes core crash (Antoine)
    - Eg, [here](https://github.com/stanfordnmbl/opencap-core/blob/dev/app.py#L146-L147)
    - We also have this API error sometimes. Let's make sure we capture it and unprotect the instance. I am pretty sure now it just crashes and the trial remains with "processing" status